### PR TITLE
Release 3.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Version 3.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.1)
+Minor fixes and improvements:
+* A more verbose CSS reset within its own SASS partial
+* Removed unnecessary offsets class (.offset-12)
+* Fixed a misspelling in one of the package.json keywords
+
 ## [Version 3.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.0)
 It's been a while, and Chassis.css has had a major overhaul. Here's what's in this release:
 * NPM

--- a/gulp/header.js
+++ b/gulp/header.js
@@ -15,7 +15,6 @@ module.exports = function(min) {
     ].join('\n');
     var bannerMin = [
         '/* <%= pkg.name %> <%= pkg.version %> | <%= pkg.license %> | <%= pkg.homepage %> */',
-        '',
         ''
     ].join('\n');
     return min ? header(bannerMin, {pkg:pkg}) : header(bannerExp, {pkg:pkg});

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "chassis-css",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The minimalistic grid & typography framework by Joel Eisner",
   "keywords": [
     "css",
     "sass",
-    "framwork",
+    "framework",
     "front-end"
   ],
   "repository": "https://github.com/joeleisner/chassis-css",

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,12 @@ The minimalistic grid & typography framework by Joel Eisner
 
 Check out the comprehensive guide and example at http://www.joeleisner.com/chassis/
 
+## [Version 3.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.1)
+Minor fixes and improvements:
+* A more verbose CSS reset within its own SASS partial
+* Removed unnecessary offsets class (.offset-12)
+* Fixed a misspelling in one of the package.json keywords
+
 ## [Version 3.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.0)
 It's been a while, and Chassis.css has had a major overhaul. Here's what's in this release:
 * NPM

--- a/src/chassis.sass
+++ b/src/chassis.sass
@@ -13,6 +13,7 @@
 @import "mixins/mq"
 
 // Partials
+@import "partials/reset"
 @import "partials/global"
 @import "partials/typography"
 @import "partials/grid"

--- a/src/mixins/_offsets.sass
+++ b/src/mixins/_offsets.sass
@@ -6,6 +6,6 @@
 
 // Generate Offsets
 =offsets-generate()
-    @for $i from 1 through $col-count
+    @for $i from 1 through ($col-count - 1)
         .offset-#{$i}
             +offset-mgn($i)

--- a/src/partials/_global.sass
+++ b/src/partials/_global.sass
@@ -6,8 +6,6 @@
 html, body
     width: 100%
     height: 100%
-    margin: 0
-    padding: 0
 
 html
     font-size: $font-size+px

--- a/src/partials/_reset.sass
+++ b/src/partials/_reset.sass
@@ -1,0 +1,8 @@
+// Reset - Partial
+
+body, html, div, blockquote, img, label, p, h1, h2, h3, h4, h5, h6, pre, ul,
+ol, li, dl, dt, dd, form, a, fieldset, input, th, td
+    margin: 0
+    padding: 0
+    border: 0
+    outline: none


### PR DESCRIPTION
* Added a more verbose CSS reset (now within its own partial)
* Updated the Gulp header module to fix the minified CSS's header output
* Fixed the offsets SASS partial's "offsets-generate" mixin (now renders col-count - 1)
* Updated the package.json by fixing a keyword misspelling and changed the version to 3.0.1
* Updated the changelog.md and readme.md to update the changelog for v3.0.1