### PR TITLE
Version 4.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Version 4.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.1)
+This patch brings some much needed stability to the framework after its big release. Here's what to expect:
+
+* Rows no longer change their `flex-direction` between `column` on extra small viewports and `row` on small viewports and above.
+    * Rows now wrap columns to vertically stack them.
+    * Vertical and horizontal alignment modifier classes no longer flip-flop functionality between extra small and small viewports.
+    * The reverse row modifier class, `.row.rev`, has been changed.
+    * The way columns fill the row's width on extra small viewports has been changed.
+* New align content modifier classes, `.ac-*`, have been added to provide more vertical alignment options.
+
 ## [Version 4.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.0)
 Chassis.css has been overhauled from the ground up to support some killer new features. Here's what you can look forward to:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis-css",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis-css",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A minimalistic grid & typography CSS framework",
   "keywords": [
     "css",

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,16 @@ A minimalistic grid & typography CSS framework. Check out the comprehensive guid
 
 ## Changelog
 
+### [Version 4.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.1)
+This patch brings some much needed stability to the framework after its big release. Here's what to expect:
+
+* Rows no longer change their `flex-direction` between `column` on extra small viewports and `row` on small viewports and above.
+    * Rows now wrap columns to vertically stack them.
+    * Vertical and horizontal alignment modifier classes no longer flip-flop functionality between extra small and small viewports.
+    * The reverse row modifier class, `.row.rev`, has been changed.
+    * The way columns fill the row's width on extra small viewports has been changed.
+* New align content modifier classes, `.ac-*`, have been added to provide more vertical alignment options.
+
 ### [Version 4.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.0)
 Chassis.css has been overhauled from the ground up to support some killer new features. Here's what you can look forward to:
 

--- a/src/mixins/grid/_alignment.sass
+++ b/src/mixins/grid/_alignment.sass
@@ -5,6 +5,8 @@
     @each $key, $value in $vertical-alignment
         .ai-#{$key}
             align-items: $value
+        .ac-#{$key}
+            align-content: $value
         .as-#{$key}
             align-self: $value
     @each $key, $value in $horizontal-alignment

--- a/src/mixins/grid/_columns.sass
+++ b/src/mixins/grid/_columns.sass
@@ -9,11 +9,12 @@
 =column-classes($breakpoint)
     @if $breakpoint == xs
         [class*='col']
-            flex: 1
-            max-width: 100%
+            +column-width(12)
             padding-left: $spacing
             padding-right: $spacing
     @else if $breakpoint == sm
+        .col
+            flex: 1
         @for $i from 1 through $column-count
             .col-#{$i}
                 +column-width($i)

--- a/src/mixins/grid/_rows.sass
+++ b/src/mixins/grid/_rows.sass
@@ -1,19 +1,11 @@
 // Mixins - Grid - Rows
 
 // Generate row class
-=row-class($breakpoint)
-    @if $breakpoint == xs
-        .row
-            display: flex
-            flex-direction: column
-            flex-wrap: nowrap
-            margin-left: -$spacing
-            margin-right: -$spacing
-            &.rev
-                flex-direction: column-reverse
-    @else if $breakpoint == sm
-        .row
-            flex-direction: row
-            flex-wrap: wrap
-            &.rev
-                flex-direction: row-reverse
+=row-class()
+    .row
+        display: flex
+        flex-wrap: wrap
+        margin-left: -$spacing
+        margin-right: -$spacing
+        &.rev
+            flex-flow: row-reverse wrap-reverse

--- a/src/partials/_grid.sass
+++ b/src/partials/_grid.sass
@@ -1,7 +1,7 @@
 // Partials - Grid
 
 +container-class('xs')
-+row-class('xs')
++row-class
 +column-classes('xs')
 +alignment-classes
 +offset-classes('xs')
@@ -9,7 +9,6 @@
 
 =grid--sm
     +container-class('sm')
-    +row-class('sm')
     +column-classes('sm')
     +offset-classes('sm')
     +order-classes('sm')


### PR DESCRIPTION
This patch brings some much needed stability to the framework after its big release. Here's what to expect:

* Rows no longer change their `flex-direction` between `column` on extra small viewports and `row` on small viewports and above.
    * Rows now wrap columns to vertically stack them.
    * Vertical and horizontal alignment modifier classes no longer flip-flop functionality between extra small and small viewports.
    * The reverse row modifier class, `.row.rev`, has been changed.
    * The way columns fill the row's width on extra small viewports has been changed.
* New align content modifier classes, `.ac-*`, have been added to provide more vertical alignment options.