### PR TITLE
4.0.2 - Root font-size no longer explicitly set

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [Version 4.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.1)
+## Current releases
+
+### [Version 4.0.2](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.2)
+This patch no longer explicitly sets the root font-size to 16px, leaving it up to the browser's default and respecting the user's preference if set. It also updates some packages to their latest version.
+
+### [Version 4.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.1)
 This patch brings some much needed stability to the framework after its big release. Here's what to expect:
 
 * Rows no longer change their `flex-direction` between `column` on extra small viewports and `row` on small viewports and above.
@@ -10,7 +15,7 @@ This patch brings some much needed stability to the framework after its big rele
     * The way columns fill the row's width on extra small viewports has been changed.
 * New align content modifier classes, `.ac-*`, have been added to provide more vertical alignment options.
 
-## [Version 4.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.0)
+### [Version 4.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.0)
 Chassis.css has been overhauled from the ground up to support some killer new features. Here's what you can look forward to:
 
 * The grid system now uses Flexbox!
@@ -23,11 +28,13 @@ Chassis.css has been overhauled from the ground up to support some killer new fe
     * Overall sizes and spacing between typography elements have been simplified dramatically.
     * New heading `.h*` classes allow you to make any typography element look like a heading.
 * Utility classes, particularly for margins/padding, have become way more concise/versatile.
-    * These classes are now constructable, allowing you to target all/specfic sides, add negative/positive adjustments, and utilize 6 levels of adjustments.
+    * These classes are now constructable, allowing you to target all/specific sides, add negative/positive adjustments, and utilize 6 levels of adjustments.
 
 Plus more! There's a lot in this update to get excited about.
 
-## [Version 3.0.2](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.2)
+## Previous releases
+
+### [Version 3.0.2](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.2)
 Even more minor fixes and improvements:
 * Proper styling for nested columns!
     * Nested rows now remove left/right padding, keeping your content aligned and visually cohesive
@@ -35,13 +42,13 @@ Even more minor fixes and improvements:
 * Gulp task names have been simplified
 * The following packages were upgraded: `autoprefixer`, `cssnano`, and `gulp-postcss`
 
-## [Version 3.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.1)
+### [Version 3.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.1)
 Minor fixes and improvements:
 * A more verbose CSS reset within its own SASS partial
 * Removed unnecessary offsets class (.offset-12)
 * Fixed a misspelling in one of the package.json keywords
 
-## [Version 3.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.0)
+### [Version 3.0.0](https://github.com/joeleisner/chassis-css/releases/tag/v3.0.0)
 It's been a while, and Chassis.css has had a major overhaul. Here's what's in this release:
 * NPM
     * The distribution CSS/SASS can now be installed with Node Package Manager
@@ -58,18 +65,18 @@ It's been a while, and Chassis.css has had a major overhaul. Here's what's in th
     * Simplified project hierarchy and structure
     * Contextual changes to SASS variables, mixins, and partials
 
-## Version 2.1.1
+### Version 2.1.1
 Just a quick fix to the iPhone orientation font-size bug
 * Added a `-webkit-text-size-adjust: 100%` to the global partial to fix the font-size enlarging when switching to landscape mode on iPhone
 
-## Version 2.1.0
+### Version 2.1.0
 After the last upgrade, it felt about time to move away from Grunt and begin using Gulp. With this new, fresh build, compiling the framework has become not only more modularized, but more accurate with a cleaner, predictable output. To learn how to compile the framework with Gulp, look in the "How to Build..." section.
 
-## Version 2.0.0
+### Version 2.0.0
 It's been awhile, but Chassis.css is back and better than ever.
 * Chassis.css is now based off of SASS. Not only will this change allow the project to be more easily maintained, it gives users even more customization options through editable variables
 * A CSS reset will no longer be shipped with Chassis.css. This change was to help allow Chassis.css become more like a SASS plugin. To do this properly, I must give creators the freedom to choose their own resets without interfering with aspects of their project
 * NPM and Grunt.js are used as the compilation tools to build out the CSS
 
-## Version 1.0.0
+### Version 1.0.0
 No version details available.

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,18 +334,78 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.6.1.tgz",
-      "integrity": "sha512-aVo5WxR3VyvyJxcJC3h4FKfwCQvQWb1tSI5VHNibddCVWrcD1NvlxEweg3TSgiPztMnWfjpy2FURKA2kvDE+Tw==",
+      "version": "9.7.3",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
+      "integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.6.3",
-        "caniuse-lite": "^1.0.30000980",
+        "browserslist": "^4.8.0",
+        "caniuse-lite": "^1.0.30001012",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.17",
-        "postcss-value-parser": "^4.0.0"
+        "postcss": "^7.0.23",
+        "postcss-value-parser": "^4.0.2"
+      },
+      "dependencies": {
+        "browserslist": {
+          "version": "4.8.2",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+          "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001015",
+            "electron-to-chromium": "^1.3.322",
+            "node-releases": "^1.1.42"
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.322",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+          "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+          "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.42",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+          "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          }
+        },
+        "postcss": {
+          "version": "7.0.24",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
+          "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "aws-sign2": {
@@ -2579,9 +2639,9 @@
       }
     },
     "gulp-rename": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
-      "integrity": "sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
       "dev": true
     },
     "gulp-sass": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis-css",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,14 +32,14 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "autoprefixer": "^9.6.1",
+    "autoprefixer": "^9.7.3",
     "cssnano": "^4.1.10",
     "gulp": "^4.0.2",
     "gulp-empty": "^0.1.2",
     "gulp-filter": "^6.0.0",
     "gulp-header": "^2.0.9",
     "gulp-postcss": "^8.0.0",
-    "gulp-rename": "^1.2.2",
+    "gulp-rename": "^2.0.0",
     "gulp-sass": "^4.0.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis-css",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A minimalistic grid & typography CSS framework",
   "keywords": [
     "css",

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,9 @@ A minimalistic grid & typography CSS framework. Check out the comprehensive guid
 
 ## Changelog
 
+### [Version 4.0.2](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.2)
+This patch no longer explicitly sets the root font-size to 16px, leaving it up to the browser's default and respecting the user's preference if set. It also updates some packages to their latest version.
+
 ### [Version 4.0.1](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.1)
 This patch brings some much needed stability to the framework after its big release. Here's what to expect:
 
@@ -28,7 +31,7 @@ Chassis.css has been overhauled from the ground up to support some killer new fe
     * Overall sizes and spacing between typography elements have been simplified dramatically.
     * New heading `.h*` classes allow you to make any typography element look like a heading.
 * Utility classes, particularly for margins/padding, have become way more concise/versatile.
-    * These classes are now constructable, allowing you to target all/specfic sides, add negative/positive adjustments, and utilize 6 levels of adjustments.
+    * These classes are now constructable, allowing you to target all/specific sides, add negative/positive adjustments, and utilize 6 levels of adjustments.
 
 Plus more! There's a lot in this update to get excited about.
 

--- a/src/partials/_reset.sass
+++ b/src/partials/_reset.sass
@@ -4,7 +4,6 @@
     box-sizing: border-box
 
 html
-    font-size: map-get($font-size, html)
     line-height: $line-height
     -webkit-font-smoothing: antialiased
     -moz-osx-font-smoothing: grayscale

--- a/src/variables/_reset.sass
+++ b/src/variables/_reset.sass
@@ -4,7 +4,7 @@
 $headings: h1, h2, h3, h4, h5, h6
 
 // Font-sizes
-$font-size: (html: 16px, h1: 2.5rem, h2: 2rem, h3: 1.75rem, h4: 1.5rem, h5: 1.25rem, h6: 1rem, small: 0.5em, blockquote: 1.25rem)
+$font-size: (h1: 2.5rem, h2: 2rem, h3: 1.75rem, h4: 1.5rem, h5: 1.25rem, h6: 1rem, small: 0.5em, blockquote: 1.25rem)
 
 // Line-height
 $line-height: 1.15


### PR DESCRIPTION
This patch no longer explicitly sets the root font-size to 16px, leaving it up to the browser's default and respecting the user's preference if set. It also updates some packages to their latest version.