### PR TITLE
4.0.3 - 1rem font-size of code elements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## Current releases
 
+### [Version 4.0.3](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.3)
+This patch explicitly sets the font-size of code elements (`pre`, `code`, `kbd`, and `samp`) to 1rem. It also updates autoprefixer and its sub-dependency of caniuse-lite to their latest versions.
+
 ### [Version 4.0.2](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.2)
 This patch no longer explicitly sets the root font-size to 16px, leaving it up to the browser's default and respecting the user's preference if set. It also updates some packages to their latest version.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis-css",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -668,10 +668,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000989",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000989.tgz",
-      "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
-      "dev": true
+      "version": "1.0.30001023",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+      "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA=="
     },
     "caseless": {
       "version": "0.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -334,56 +334,56 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.7.3",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.3.tgz",
-      "integrity": "sha512-8T5Y1C5Iyj6PgkPSFd0ODvK9DIleuPKUPYniNxybS47g2k2wFgLZ46lGQHlBuGKIAEV8fbCDfKCCRS1tvOgc3Q==",
+      "version": "9.7.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.4.tgz",
+      "integrity": "sha512-g0Ya30YrMBAEZk60lp+qfX5YQllG+S5W3GYCFvyHTvhOki0AEQJLPEcIuGRsqVwLi8FvXPVtwTGhfr38hVpm0g==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.8.0",
-        "caniuse-lite": "^1.0.30001012",
+        "browserslist": "^4.8.3",
+        "caniuse-lite": "^1.0.30001020",
         "chalk": "^2.4.2",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
-        "postcss": "^7.0.23",
+        "postcss": "^7.0.26",
         "postcss-value-parser": "^4.0.2"
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.8.2",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-          "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+          "version": "4.8.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.5.tgz",
+          "integrity": "sha512-4LMHuicxkabIB+n9874jZX/az1IaZ5a+EUuvD7KFOu9x/Bd5YHyO0DIz2ls/Kl8g0ItS4X/ilEgf4T1Br0lgSg==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30001015",
-            "electron-to-chromium": "^1.3.322",
-            "node-releases": "^1.1.42"
+            "caniuse-lite": "^1.0.30001022",
+            "electron-to-chromium": "^1.3.338",
+            "node-releases": "^1.1.46"
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001015",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+          "version": "1.0.30001023",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001023.tgz",
+          "integrity": "sha512-C5TDMiYG11EOhVOA62W1p3UsJ2z4DsHtMBQtjzp3ZsUglcQn62WOUgW0y795c7A5uZ+GCEIvzkMatLIlAsbNTA==",
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.322",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-          "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+          "version": "1.3.340",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.340.tgz",
+          "integrity": "sha512-hRFBAglhcj5iVYH+o8QU0+XId1WGoc0VGowJB1cuJAt3exHGrivZvWeAO5BRgBZqwZtwxjm8a5MQeGoT/Su3ww==",
           "dev": true
         },
         "node-releases": {
-          "version": "1.1.42",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
-          "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+          "version": "1.1.47",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.47.tgz",
+          "integrity": "sha512-k4xjVPx5FpwBUj0Gw7uvFOTF4Ep8Hok1I6qjwL3pLfwe7Y0REQSAqOwwv9TWBCUtMHxcXfY4PgRLRozcChvTcA==",
           "dev": true,
           "requires": {
             "semver": "^6.3.0"
           }
         },
         "postcss": {
-          "version": "7.0.24",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-          "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+          "version": "7.0.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.26.tgz",
+          "integrity": "sha512-IY4oRjpXWYshuTDFxMVkJDtWIk2LhsTlu8bZnbEJA4+bYT16Lvpo8Qv6EvDumhYRgzjZl489pmsY3qVgJQ08nA==",
           "dev": true,
           "requires": {
             "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "autoprefixer": "^9.7.3",
+    "autoprefixer": "^9.7.4",
     "cssnano": "^4.1.10",
     "gulp": "^4.0.2",
     "gulp-empty": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chassis-css",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "A minimalistic grid & typography CSS framework",
   "keywords": [
     "css",

--- a/readme.md
+++ b/readme.md
@@ -5,6 +5,9 @@ A minimalistic grid & typography CSS framework. Check out the comprehensive guid
 
 ## Changelog
 
+### [Version 4.0.3](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.3)
+This patch explicitly sets the font-size of code elements (`pre`, `code`, `kbd`, and `samp`) to 1rem. It also updates autoprefixer and its sub-dependency of caniuse-lite to their latest versions.
+
 ### [Version 4.0.2](https://github.com/joeleisner/chassis-css/releases/tag/v4.0.2)
 This patch no longer explicitly sets the root font-size to 16px, leaving it up to the browser's default and respecting the user's preference if set. It also updates some packages to their latest version.
 

--- a/src/partials/_reset.sass
+++ b/src/partials/_reset.sass
@@ -44,3 +44,6 @@ fieldset
     margin: 0
     padding: 0
     border: 0
+
+pre, code, kbd, samp
+    font-size: map-get($font-size, monospace)

--- a/src/variables/_reset.sass
+++ b/src/variables/_reset.sass
@@ -4,7 +4,7 @@
 $headings: h1, h2, h3, h4, h5, h6
 
 // Font-sizes
-$font-size: (h1: 2.5rem, h2: 2rem, h3: 1.75rem, h4: 1.5rem, h5: 1.25rem, h6: 1rem, small: 0.5em, blockquote: 1.25rem)
+$font-size: (h1: 2.5rem, h2: 2rem, h3: 1.75rem, h4: 1.5rem, h5: 1.25rem, h6: 1rem, small: 0.5em, blockquote: 1.25rem, monospace: 1rem)
 
 // Line-height
 $line-height: 1.15


### PR DESCRIPTION
- 4.0.3
- Updated autoprefixer to version 9.7.4
- Updated the sub dependency, caniuse-lite, of autoprefixer to 1.0.30001023. This is because browserslist was outputting a warning when running the build system.
- Updated the reset variables and partial to include a style override for code related elements, such as pre, code, kbd, and samp. This is because on most browsers, these elements do not have 1rem font-sizes, instead being smaller (often explicitly set to 14px). This style override forces these code related elements to have 1rem font-sizes by default.
- Updated the readme and changelog markdown files to include documentation for the 4.0.3 patch release.